### PR TITLE
add check for unsubscribed before next read 

### DIFF
--- a/src/main/java/rx/observables/StringObservable.java
+++ b/src/main/java/rx/observables/StringObservable.java
@@ -176,7 +176,8 @@ public class StringObservable {
                     n = i.read(buffer);
                     while (n != -1 && !o.isUnsubscribed()) {
                         o.onNext(new String(buffer, 0, n));
-                        n = i.read(buffer);
+                        if (!o.isUnsubscribed())
+                            n = i.read(buffer);
                     }
                 } catch (IOException e) {
                     o.onError(e);


### PR DESCRIPTION
A while back I contributed a PR to add this check for `StringObservable.from(InputStream)`. The same check for unsubscribed should also be against `StringObservable.from(Reader)`. 

Included unit test in PR.
