### PR TITLE
Add backpressure support for StringObservable.from(InputStream)

### DIFF
--- a/src/main/java/rx/observables/StringObservable.java
+++ b/src/main/java/rx/observables/StringObservable.java
@@ -18,6 +18,7 @@ package rx.observables;
 import rx.Observable;
 import rx.Observable.OnSubscribe;
 import rx.Observable.Operator;
+import rx.Producer;
 import rx.Subscriber;
 import rx.functions.Action1;
 import rx.functions.Func0;
@@ -38,7 +39,9 @@ import java.nio.charset.CoderResult;
 import java.nio.charset.CodingErrorAction;
 import java.util.Arrays;
 import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Pattern;
+
 
 public class StringObservable {
     /**
@@ -114,28 +117,106 @@ public class StringObservable {
      *            internal buffer size
      * @return the Observable containing read byte arrays from the input
      */
-    public static Observable<byte[]> from(final InputStream i, final int size) {
+    public static Observable<byte[]> from(final InputStream is, final int size) {
         return Observable.create(new OnSubscribe<byte[]>() {
             @Override
-            public void call(Subscriber<? super byte[]> o) {
-                byte[] buffer = new byte[size];
-                try {
-                    if (o.isUnsubscribed())
-                        return;
-                    int n = i.read(buffer);
-                    while (n != -1 && !o.isUnsubscribed()) {
-                        o.onNext(Arrays.copyOf(buffer, n));
-                        if (!o.isUnsubscribed())
-                            n = i.read(buffer);
-                    }
-                } catch (IOException e) {
-                    o.onError(e);
-                }
-                if (o.isUnsubscribed())
-                    return;
-                o.onCompleted();
+            public void call(Subscriber<? super byte[]> subscriber) {
+               subscriber.setProducer(new InputStreamProducer(is, subscriber, size));
             }
         });
+    }
+    
+    private static class InputStreamProducer implements Producer {
+
+        private final AtomicLong requested = new AtomicLong(0);
+        private final InputStream is;
+        private final Subscriber<? super byte[]> subscriber;
+        private int size;
+        
+        InputStreamProducer(InputStream is, Subscriber<? super byte[]> subscriber, int size) {
+            this.is = is;
+            this.subscriber = subscriber;
+            this.size = size;
+        }
+        
+        @Override
+        public void request(long n) {
+            try {
+                if (requested.get() == Long.MAX_VALUE)
+                    // already started with fast path
+                    return;
+                else if (n == Long.MAX_VALUE) {
+                    // fast path
+                    requestAll();
+                } else 
+                    requestSome(n);
+            } catch (RuntimeException e) {
+                subscriber.onError(e);
+            } catch (IOException e) {
+                subscriber.onError(e);
+            }
+        }
+
+        private void requestAll() {
+            requested.set(Long.MAX_VALUE);
+            byte[] buffer = new byte[size];
+            try {
+                if (subscriber.isUnsubscribed())
+                    return;
+                int n = is.read(buffer);
+                while (n != -1 && !subscriber.isUnsubscribed()) {
+                    subscriber.onNext(Arrays.copyOf(buffer, n));
+                    if (!subscriber.isUnsubscribed())
+                        n = is.read(buffer);
+                }
+            } catch (IOException e) {
+                subscriber.onError(e);
+            }
+            if (subscriber.isUnsubscribed())
+                return;
+            subscriber.onCompleted();
+        }
+        
+        
+
+        private void requestSome(long n) throws IOException {
+            // back pressure path
+            // this algorithm copied roughly from
+            // rxjava/OnSubscribeFromIterable.java
+
+            long previousCount = requested.getAndAdd(n);
+            if (previousCount == 0) {
+                byte[] buffer = new byte[size];
+                while (true) {
+                    long r = requested.get();
+                    long numToEmit = r;
+
+                    //emit numToEmit
+                    
+                    if (subscriber.isUnsubscribed())
+                        return;
+                    int numRead;
+                    if (numToEmit>0)
+                        numRead = is.read(buffer);
+                    else 
+                        numRead = 0;
+                    while (numRead != -1 && !subscriber.isUnsubscribed() && numToEmit>0) {
+                        subscriber.onNext(Arrays.copyOf(buffer, numRead));
+                        numToEmit--;
+                        if (numToEmit >0 && !subscriber.isUnsubscribed())
+                            numRead = is.read(buffer);
+                    }
+                    
+                    //check if we have finished
+                    if (numRead == -1 && !subscriber.isUnsubscribed()) 
+                        subscriber.onCompleted();
+                    else if (subscriber.isUnsubscribed())
+                        return;
+                    else if (requested.addAndGet(-r) == 0)
+                        return;
+                }
+            }
+        }
     }
 
     /**

--- a/src/main/java/rx/observables/StringObservable.java
+++ b/src/main/java/rx/observables/StringObservable.java
@@ -176,7 +176,8 @@ public class StringObservable {
                     n = i.read(buffer);
                     while (n != -1 && !o.isUnsubscribed()) {
                         o.onNext(new String(buffer, 0, n));
-                        n = i.read(buffer);
+                        if (!o.isUnsubscribed())
+                            n = i.read(buffer);
                     }
                 } catch (IOException e) {
                     o.onError(e);


### PR DESCRIPTION
backpressure support added for `StringObservable.from(InputStream)` including a few unit tests.

Once this PR makes it through can add a similar one for `StringObservable.from(Reader)`.
