### PR TITLE
use AbstractOnSubscribe for StringObservable.from(InputStream) and from(Reader)

### DIFF
--- a/src/main/java/rx/internal/operators/OnSubscribeInputStream.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeInputStream.java
@@ -1,0 +1,42 @@
+package rx.internal.operators;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+
+import rx.Subscriber;
+import rx.observables.AbstractOnSubscribe;
+
+public final class OnSubscribeInputStream extends AbstractOnSubscribe<byte[], InputStream> {
+
+    private final InputStream is;
+    private final int size;
+
+    public OnSubscribeInputStream(InputStream is, int size) {
+        this.is = is;
+        this.size = size;
+    }
+
+    @Override
+    protected InputStream onSubscribe(Subscriber<? super byte[]> subscriber) {
+        return is;
+    }
+
+    @Override
+    protected void next(SubscriptionState<byte[], InputStream> state) {
+
+        InputStream is = state.state();
+        byte[] buffer = new byte[size];
+        try {
+            int count = is.read(buffer);
+            if (count == -1)
+                state.onCompleted();
+            else if (count < size)
+                state.onNext(Arrays.copyOf(buffer, count));
+            else
+                state.onNext(buffer);
+        } catch (IOException e) {
+            state.onError(e);
+        }
+    }
+}

--- a/src/main/java/rx/internal/operators/OnSubscribeReader.java
+++ b/src/main/java/rx/internal/operators/OnSubscribeReader.java
@@ -1,0 +1,39 @@
+package rx.internal.operators;
+
+import java.io.IOException;
+import java.io.Reader;
+
+import rx.Subscriber;
+import rx.observables.AbstractOnSubscribe;
+
+public final class OnSubscribeReader extends AbstractOnSubscribe<String, Reader> {
+
+    private final Reader reader;
+    private final int size;
+
+    public OnSubscribeReader(Reader reader, int size) {
+        this.reader = reader;
+        this.size = size;
+    }
+
+    @Override
+    protected Reader onSubscribe(Subscriber<? super String> subscriber) {
+        return reader;
+    }
+
+    @Override
+    protected void next(SubscriptionState<String, Reader> state) {
+
+        Reader reader = state.state();
+        char[] buffer = new char[size];
+        try {
+            int count = reader.read(buffer);
+            if (count == -1)
+                state.onCompleted();
+            else
+                state.onNext(String.valueOf(buffer, 0, count));
+        } catch (IOException e) {
+            state.onError(e);
+        }
+    }
+}


### PR DESCRIPTION
This PR uses `AbstractOnSubscribe` to provide much simpler implementations of `StringObservable.from(InputStream)` and `StringObservable.from(Reader)` that support backpressure.

This PR also
- fixes grammar in javadoc
- fixes spelling in tests
- removes an unused import
- upgrades rxjava dependency to 1.0.9 (required so that `AbstractOnSubscribe` bug https://github.com/ReactiveX/RxJava/issues/2853 is fixed)
