### PR TITLE
Use explicit versions in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 buildscript {
   repositories { jcenter() }
-  dependencies { classpath 'com.netflix.nebula:gradle-rxjava-project-plugin:2.+' }
+  dependencies { classpath 'com.netflix.nebula:gradle-rxjava-project-plugin:2.2.3' }
 }
 
 apply plugin: 'rxjava-project'
 apply plugin: 'java'
 
 dependencies {
-    compile 'io.reactivex:rxjava:1.0.+'
+    compile 'io.reactivex:rxjava:1.0.9'
     testCompile 'junit:junit-dep:4.10'
     testCompile 'org.mockito:mockito-core:1.8.5'
 }


### PR DESCRIPTION
Build is not deterministic without explicit dependency version so have used latest version from Maven Central for `gradle-rxjava-project-plugin` 2.2.3.

As per https://github.com/ReactiveX/RxJava/pull/2871
