### PR TITLE
ensure StringObservable.join does not stall

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'rxjava-project'
 apply plugin: 'java'
 
 dependencies {
-    compile 'io.reactivex:rxjava:1.0.+'
+    compile 'io.reactivex:rxjava:1.0.12'
     testCompile 'junit:junit-dep:4.10'
     testCompile 'org.mockito:mockito-core:1.8.5'
 }


### PR DESCRIPTION
`StringObservable.join` passed through requests from child subscriber only and instead needed to request `Long.MAX_VALUE` of upstream because only emits on completion. 

@akarnokd I did slightly more than you suggested so that initial request was Long.MAX_VALUE but also decoupled the parent subscriber from further requests from child subscriber.

PR includes unit test that failed on existing code.
